### PR TITLE
Generate volume sliders from project buses

### DIFF
--- a/addons/EasyMenus/Scenes/options_menu.tscn
+++ b/addons/EasyMenus/Scenes/options_menu.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://qlskttl1wjr7"]
+[gd_scene load_steps=6 format=3 uid="uid://qlskttl1wjr7"]
 
 [ext_resource type="Script" path="res://addons/EasyMenus/Scripts/options_menu_controller.gd" id="1_h6k46"]
 [ext_resource type="Script" path="res://addons/EasyMenus/Scripts/follow_focus_center.gd" id="2_l3n3h"]
-[ext_resource type="PackedScene" path="res://addons/EasyMenus/Nodes/slider_w_labels.tscn" id="3_xghjq"]
 [ext_resource type="Script" path="res://addons/EasyMenus/Scripts/option_button_input_propagator.gd" id="4_02jwa"]
-[ext_resource type="PackedScene" path="res://addons/EasyMenus/Nodes/gamepad_closable.tscn" id="5_k4nlh"]
+[ext_resource type="PackedScene" uid="uid://cqniig2ks0xs2" path="res://addons/EasyMenus/Nodes/gamepad_closable.tscn" id="5_k4nlh"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_x77mt"]
 
@@ -18,7 +17,7 @@ grow_vertical = 2
 script = ExtResource("1_h6k46")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -29,108 +28,42 @@ theme_override_constants/margin_right = 25
 theme_override_constants/margin_bottom = 25
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer"]
-offset_left = 25.0
-offset_top = 25.0
-offset_right = 775.0
-offset_bottom = 575.0
-grow_horizontal = 2
-grow_vertical = 2
+layout_mode = 2
 script = ExtResource("2_l3n3h")
 transition_time = 0.15
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer"]
-offset_right = 742.0
-offset_bottom = 851.0
-grow_horizontal = 2
-grow_vertical = 2
+layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 15
 
 [node name="OptionsTitle" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_right = 742.0
-offset_bottom = 66.0
+layout_mode = 2
 theme_override_font_sizes/font_size = 45
 text = "Options"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_top = 81.0
-offset_right = 742.0
-offset_bottom = 91.0
+layout_mode = 2
 theme_override_constants/separation = 10
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_top = 106.0
-offset_right = 742.0
-offset_bottom = 296.0
+layout_mode = 2
 theme_override_constants/margin_left = 100
 theme_override_constants/margin_right = 100
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer"]
-offset_left = 100.0
-offset_right = 642.0
-offset_bottom = 190.0
-
-[node name="SFXVolumeSlider" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer" instance=ExtResource("3_xghjq")]
+[node name="VolumeSlidersContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer"]
 unique_name_in_owner = true
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_right = 542.0
-offset_bottom = 93.0
-grow_horizontal = 1
-grow_vertical = 1
-title = "SFX Volume"
-
-[node name="Title" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/SFXVolumeSlider" index="0"]
-offset_right = 542.0
-text = "SFX Volume"
-
-[node name="HSlider" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/SFXVolumeSlider" index="1"]
-offset_right = 542.0
-max_value = 1.0
-step = 0.1
-
-[node name="CurrentValue" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/SFXVolumeSlider" index="2"]
-offset_right = 542.0
-
-[node name="MusicVolumeSlider" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer" instance=ExtResource("3_xghjq")]
-unique_name_in_owner = true
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_top = 97.0
-offset_right = 542.0
-offset_bottom = 190.0
-grow_horizontal = 1
-grow_vertical = 1
-title = "Music Volume"
-
-[node name="Title" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/MusicVolumeSlider" index="0"]
-offset_right = 542.0
-text = "Music Volume"
-
-[node name="HSlider" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/MusicVolumeSlider" index="1"]
-offset_right = 542.0
-max_value = 1.0
-step = 0.1
-
-[node name="CurrentValue" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/MusicVolumeSlider" index="2"]
-offset_right = 542.0
+layout_mode = 2
 
 [node name="HSeparator2" type="HSeparator" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_top = 311.0
-offset_right = 742.0
-offset_bottom = 321.0
+layout_mode = 2
 theme_override_constants/separation = 10
 
 [node name="FullscreenCheckButton" type="CheckButton" parent="MarginContainer/ScrollContainer/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
-offset_left = 271.0
-offset_top = 336.0
-offset_right = 471.0
-offset_bottom = 379.0
+layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 25
 text = "Fullscreen"
@@ -138,41 +71,31 @@ text = "Fullscreen"
 [node name="VSyncCheckButton" type="CheckButton" parent="MarginContainer/ScrollContainer/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
-offset_left = 271.0
-offset_top = 394.0
-offset_right = 471.0
-offset_bottom = 437.0
+layout_mode = 2
 size_flags_horizontal = 4
 tooltip_text = "Syncs Games Frame Rate with Displays Refresh Rate"
 theme_override_font_sizes/font_size = 25
 text = "V-Sync"
 
 [node name="MarginContainer2" type="MarginContainer" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_top = 452.0
-offset_right = 742.0
-offset_bottom = 545.0
+layout_mode = 2
 theme_override_constants/margin_left = 100
 theme_override_constants/margin_right = 100
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer2"]
-offset_left = 100.0
-offset_right = 642.0
-offset_bottom = 93.0
+layout_mode = 2
 tooltip_text = "Scale Less than 1 to get performance improve. 
 Scale to more than 1 to improve image quality."
 
 [node name="RenderScaleLabel" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer2/VBoxContainer"]
-offset_right = 542.0
-offset_bottom = 38.0
+layout_mode = 2
 theme_override_font_sizes/font_size = 25
 text = "Render Scale"
 horizontal_alignment = 1
 
 [node name="RenderScaleSlider" type="HSlider" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer2/VBoxContainer"]
 unique_name_in_owner = true
-offset_top = 42.0
-offset_right = 542.0
-offset_bottom = 58.0
+layout_mode = 2
 mouse_force_pass_scroll_events = false
 min_value = 0.25
 max_value = 2.0
@@ -181,38 +104,29 @@ value = 1.0
 
 [node name="RenderScaleCurrentValueLabel" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer2/VBoxContainer"]
 unique_name_in_owner = true
-offset_top = 62.0
-offset_right = 542.0
-offset_bottom = 93.0
+layout_mode = 2
 theme_override_font_sizes/font_size = 20
 text = "1"
 horizontal_alignment = 1
 
 [node name="MarginContainer3" type="MarginContainer" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_top = 560.0
-offset_right = 742.0
-offset_bottom = 728.0
+layout_mode = 2
 theme_override_constants/margin_left = 100
 theme_override_constants/margin_right = 100
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3"]
-offset_left = 100.0
-offset_right = 642.0
-offset_bottom = 168.0
+layout_mode = 2
 theme_override_constants/separation = 10
 
 [node name="AntiAliasing2DLabel" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer"]
-offset_right = 542.0
-offset_bottom = 38.0
+layout_mode = 2
 theme_override_font_sizes/font_size = 25
 text = "2D Anti Aliasing"
 horizontal_alignment = 1
 
 [node name="AntiAliasing2DOptionButton" type="OptionButton" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer"]
 unique_name_in_owner = true
-offset_top = 48.0
-offset_right = 542.0
-offset_bottom = 79.0
+layout_mode = 2
 tooltip_text = "Smooth out edges of 2D objects"
 item_count = 4
 selected = 0
@@ -229,18 +143,14 @@ script = ExtResource("4_02jwa")
 [node name="GamepadClosable" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer/AntiAliasing2DOptionButton" instance=ExtResource("5_k4nlh")]
 
 [node name="AntiAliasing3DLabel" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer"]
-offset_top = 89.0
-offset_right = 542.0
-offset_bottom = 127.0
+layout_mode = 2
 theme_override_font_sizes/font_size = 25
 text = "3D Anti Aliasing"
 horizontal_alignment = 1
 
 [node name="AntiAliasing3DOptionButton" type="OptionButton" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer"]
 unique_name_in_owner = true
-offset_top = 137.0
-offset_right = 542.0
-offset_bottom = 168.0
+layout_mode = 2
 tooltip_text = "Smooths out edges of 3D objects"
 item_count = 4
 selected = 0
@@ -257,33 +167,21 @@ script = ExtResource("4_02jwa")
 [node name="GamepadClosable" parent="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer/AntiAliasing3DOptionButton" instance=ExtResource("5_k4nlh")]
 
 [node name="HSeparator3" type="HSeparator" parent="MarginContainer/ScrollContainer/VBoxContainer"]
-offset_top = 743.0
-offset_right = 742.0
-offset_bottom = 793.0
+layout_mode = 2
 theme_override_constants/separation = 50
 theme_override_styles/separator = SubResource("StyleBoxEmpty_x77mt")
 
 [node name="BackButton" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer"]
 custom_minimum_size = Vector2(350, 0)
-offset_left = 196.0
-offset_top = 808.0
-offset_right = 546.0
-offset_bottom = 851.0
-grow_horizontal = 2
-grow_vertical = 0
+layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 8
 theme_override_font_sizes/font_size = 25
 text = "Back"
 
-[connection signal="value_changed" from="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/SFXVolumeSlider" to="." method="_on_sfx_volume_slider_value_changed"]
-[connection signal="value_changed" from="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/MusicVolumeSlider" to="." method="_on_music_volume_slider_value_changed"]
 [connection signal="toggled" from="MarginContainer/ScrollContainer/VBoxContainer/FullscreenCheckButton" to="." method="_on_fullscreen_check_button_toggled"]
 [connection signal="toggled" from="MarginContainer/ScrollContainer/VBoxContainer/VSyncCheckButton" to="." method="_on_v_sync_check_button_toggled"]
 [connection signal="value_changed" from="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer2/VBoxContainer/RenderScaleSlider" to="." method="_on_render_scale_slider_value_changed"]
 [connection signal="item_selected" from="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer/AntiAliasing2DOptionButton" to="." method="_on_anti_aliasing_2d_option_button_item_selected"]
 [connection signal="item_selected" from="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer3/VBoxContainer/AntiAliasing3DOptionButton" to="." method="_on_anti_aliasing_3d_option_button_item_selected"]
 [connection signal="pressed" from="MarginContainer/ScrollContainer/VBoxContainer/BackButton" to="." method="go_back"]
-
-[editable path="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/SFXVolumeSlider"]
-[editable path="MarginContainer/ScrollContainer/VBoxContainer/MarginContainer/VBoxContainer/MusicVolumeSlider"]

--- a/addons/EasyMenus/Scripts/options_constants.gd
+++ b/addons/EasyMenus/Scripts/options_constants.gd
@@ -1,13 +1,9 @@
 extends Node
 class_name OptionsConstants
 
-const sfx_bus_name = "SFX"
-const music_bus_name = "Music" 
 const config_file_name = "user://options.cfg"
 
 const section_name = "Options" 
-const sfx_volume_key_name = "sfx_volume"
-const music_volume_key_name = "music_volume" 
 const fullscreen_key_name = "fullscreen"
 const render_scale_key = "render_scale"
 const vsync_key = "vsync"

--- a/addons/EasyMenus/Scripts/options_menu_controller.gd
+++ b/addons/EasyMenus/Scripts/options_menu_controller.gd
@@ -1,10 +1,9 @@
 extends Control
 signal  close
 
-const HSliderWLabel = preload("res://addons/EasyMenus/Scripts/slider_w_labels.gd")
+const HSliderWLabel := preload("res://addons/EasyMenus/Nodes/slider_w_labels.tscn")
 
-@onready var sfx_volume_slider : HSliderWLabel = $%SFXVolumeSlider
-@onready var music_volume_slider: HSliderWLabel = $%MusicVolumeSlider
+@onready var volume_sliders_container: VBoxContainer = %VolumeSlidersContainer
 @onready var fullscreen_check_button: CheckButton = $%FullscreenCheckButton
 @onready var render_scale_current_value_label: Label = $%RenderScaleCurrentValueLabel
 @onready var render_scale_slider: HSlider = $%RenderScaleSlider
@@ -12,10 +11,24 @@ const HSliderWLabel = preload("res://addons/EasyMenus/Scripts/slider_w_labels.gd
 @onready var anti_aliasing_2d_option_button: OptionButton = $%AntiAliasing2DOptionButton
 @onready var anti_aliasing_3d_option_button: OptionButton = $%AntiAliasing3DOptionButton
 
-var sfx_bus_index
-var music_bus_index
+var volume_sliders := {}
 var config = ConfigFile.new()
 
+
+func _ready():
+	for bus_index in range(AudioServer.bus_count):
+		var volume_slider := HSliderWLabel.instantiate() as SliderWithLabels
+		var bus_name := AudioServer.get_bus_name(bus_index)
+		var volume_slider_name = bus_name + "VolumeSlider"
+		volume_sliders[volume_slider_name] = volume_slider
+		volume_slider.name = volume_slider_name
+		volume_slider.unique_name_in_owner = true
+		volume_slider.title = bus_name + " Volume"
+		volume_slider.value_changed.connect(_on_volume_slider_value_changed.bind(bus_index))
+		volume_sliders_container.add_child(volume_slider)
+		volume_slider.hslider.step = 0.1
+		volume_slider.hslider.max_value = 1.0
+		volume_slider.hslider.value = db_to_linear(AudioServer.get_bus_volume_db(bus_index))
 
 # Emits close signal and saves the options
 func go_back():
@@ -24,27 +37,29 @@ func go_back():
 
 # Called from outside initializes the options menu
 func on_open():
-	sfx_volume_slider.hslider.grab_focus()
-	
-	sfx_bus_index = AudioServer.get_bus_index(OptionsConstants.sfx_bus_name)
-	music_bus_index = AudioServer.get_bus_index(OptionsConstants.music_bus_name)
+	volume_sliders_container.get_child(0).hslider.grab_focus()
 	
 	load_options()
 
-func _on_sfx_volume_slider_value_changed(value):
-	set_volume(sfx_bus_index, value)
 
-func _on_music_volume_slider_value_changed(value):
-	set_volume(music_bus_index, value)
+func _on_volume_slider_value_changed(value, bus_index) -> void:
+	set_volume(bus_index, value)
+
 
 # Sets the volume for the given audio bus
 func set_volume(bus_index, value):
 	AudioServer.set_bus_volume_db(bus_index, linear_to_db(value))
-	
+
+
 # Saves the options when the options menu is closed
 func save_options():
-	config.set_value(OptionsConstants.section_name,OptionsConstants.sfx_volume_key_name, sfx_volume_slider.hslider.value)
-	config.set_value(OptionsConstants.section_name, OptionsConstants.music_volume_key_name, music_volume_slider.hslider.value)
+	# Save volume levels
+	for bus_index in range(AudioServer.bus_count):
+		var bus_name := AudioServer.get_bus_name(bus_index)
+		var volume_key_name := bus_name + "_volume"
+		var volume_slider := volume_sliders[bus_name + "VolumeSlider"] as SliderWithLabels
+		config.set_value(OptionsConstants.section_name, volume_key_name, volume_slider.hslider.value)
+	
 	config.set_value(OptionsConstants.section_name, OptionsConstants.fullscreen_key_name, fullscreen_check_button.button_pressed)
 	config.set_value(OptionsConstants.section_name, OptionsConstants.render_scale_key, render_scale_slider.value);
 	config.set_value(OptionsConstants.section_name, OptionsConstants.vsync_key, vsync_check_button.button_pressed)
@@ -53,21 +68,27 @@ func save_options():
 	
 	config.save(OptionsConstants.config_file_name)
 
+
 # Loads options and sets the controls values to loaded values. Uses default values if config file
 # does not exist
 func load_options():
 	var err = config.load(OptionsConstants.config_file_name)
 	
-	var sfx_volume = config.get_value(OptionsConstants.section_name, OptionsConstants.sfx_volume_key_name, 1)
-	var music_volume = config.get_value(OptionsConstants.section_name, OptionsConstants.music_volume_key_name, 1)
+	# Load volume levels
+	for bus_index in range(AudioServer.bus_count):
+		var bus_name := AudioServer.get_bus_name(bus_index)
+		var volume_key_name := bus_name + "_volume"
+		var volume := config.get_value(OptionsConstants.section_name, volume_key_name, 1)
+		var volume_slider := volume_sliders[bus_name + "VolumeSlider"] as SliderWithLabels
+		volume_slider.hslider.value = volume
+		config.set_value(OptionsConstants.section_name, volume_key_name, volume_slider.hslider.value)
+	
 	var fullscreen = config.get_value(OptionsConstants.section_name, OptionsConstants.fullscreen_key_name, false)
 	var render_scale = config.get_value(OptionsConstants.section_name, OptionsConstants.render_scale_key, 1)
 	var vsync = config.get_value(OptionsConstants.section_name, OptionsConstants.vsync_key, true)
 	var msaa_2d = config.get_value(OptionsConstants.section_name, OptionsConstants.msaa_2d_key, 0)
 	var msaa_3d = config.get_value(OptionsConstants.section_name, OptionsConstants.msaa_3d_key, 0)
-
-	sfx_volume_slider.hslider.value = sfx_volume
-	music_volume_slider.hslider.value = music_volume
+	
 	fullscreen_check_button.button_pressed = fullscreen
 	render_scale_slider.value = render_scale
 	
@@ -80,6 +101,7 @@ func load_options():
 	anti_aliasing_3d_option_button.selected = msaa_3d
 	anti_aliasing_3d_option_button.emit_signal("item_selected", msaa_3d)
 
+
 func _on_fullscreen_check_button_toggled(button_pressed):
 	if button_pressed:
 		if DisplayServer.window_get_mode() != DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
@@ -87,7 +109,7 @@ func _on_fullscreen_check_button_toggled(button_pressed):
 	else:
 		if DisplayServer.window_get_mode() != DisplayServer.WINDOW_MODE_WINDOWED:
 			DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-		
+
 
 func _on_render_scale_slider_value_changed(value):
 	get_viewport().scaling_3d_scale = value
@@ -108,8 +130,10 @@ func _on_v_sync_check_button_toggled(button_pressed):
 func _on_anti_aliasing_2d_option_button_item_selected(index):
 	set_msaa("msaa_2d", index)
 
+
 func _on_anti_aliasing_3d_option_button_item_selected(index):
 	set_msaa("msaa_3d", index)
+
 
 func set_msaa(mode, index):
 	match index:
@@ -121,6 +145,7 @@ func set_msaa(mode, index):
 			get_viewport().set(mode,Viewport.MSAA_4X)
 		3:
 			get_viewport().set(mode,Viewport.MSAA_8X)
+
 
 func _input(event):
 	if event.is_action_pressed("ui_cancel") && visible:

--- a/addons/EasyMenus/Scripts/slider_w_labels.gd
+++ b/addons/EasyMenus/Scripts/slider_w_labels.gd
@@ -1,5 +1,7 @@
 @tool
 extends VBoxContainer
+class_name SliderWithLabels
+
 signal value_changed(value: float)
 
 @onready var title_label : Label = $Title

--- a/addons/EasyMenus/Scripts/startup_loader.gd
+++ b/addons/EasyMenus/Scripts/startup_loader.gd
@@ -11,18 +11,18 @@ func load_settings():
 	if err != OK:
 		return
 	
-	var sfx_bus_index = AudioServer.get_bus_index(OptionsConstants.sfx_bus_name)
-	var music_bus_index = AudioServer.get_bus_index(OptionsConstants.music_bus_name)
-	var sfx_volume = linear_to_db(config.get_value(OptionsConstants.section_name, OptionsConstants.sfx_volume_key_name, 1))
-	var music_volume = linear_to_db(config.get_value(OptionsConstants.section_name, OptionsConstants.music_volume_key_name, 1))
+	for bus_index in range(AudioServer.bus_count):
+		var bus_name := AudioServer.get_bus_name(bus_index)
+		var volume_key_name := bus_name + "_volume"
+		var volume := linear_to_db(config.get_value(OptionsConstants.section_name, volume_key_name, 1))
+		AudioServer.set_bus_volume_db(bus_index, volume)
+	
 	var fullscreen = config.get_value(OptionsConstants.section_name, OptionsConstants.fullscreen_key_name, false)
 	var render_scale = config.get_value(OptionsConstants.section_name, OptionsConstants.render_scale_key, 1)
 	var vsync = config.get_value(OptionsConstants.section_name, OptionsConstants.vsync_key, true)
 	var msaa_2d = config.get_value(OptionsConstants.section_name, OptionsConstants.msaa_2d_key, 0)
 	var msaa_3d = config.get_value(OptionsConstants.section_name, OptionsConstants.msaa_3d_key, 0)
 	
-	AudioServer.set_bus_volume_db(sfx_bus_index, sfx_volume)
-	AudioServer.set_bus_volume_db(music_bus_index, music_volume)
 	if fullscreen:
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
 	else:


### PR DESCRIPTION
Instead of hardcoding a Music and SFX bus, this will instead generate sliders based on the audio buses already defined in the project, including the master bus. The labels will display "{Bus Name} Volume".

I'm making this change because when I was trying to implement into my already existing project, I had more audio buses than just Music and Sfx, and it was a little bit of a chore to add new volume sliders and change the existing ones.

This new system should be more flexible, but comes at the downside that the user will have to make changes to the slider node separately from the main options menu scene.