### PR TITLE
Avoid leak of the InputMapUpdater instance

### DIFF
--- a/addons/EasyMenus/Scripts/menu_template_manager.gd
+++ b/addons/EasyMenus/Scripts/menu_template_manager.gd
@@ -2,13 +2,17 @@ extends Node
 const OptionConstants = preload("res://addons/EasyMenus/Scripts/options_constants.gd")
 const InputMapUpdater = preload("res://addons/EasyMenus/Scripts/input_map_updater.gd")
 
+var _input_map_updater: InputMapUpdater = null
+
 @onready var ControllerEchoInputGenerator = $ControllerEchoInputGenerator
 @onready var startup_loader = $StartupLoader
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	InputMapUpdater.new()._ready()
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
+func _ready():
+	_input_map_updater = InputMapUpdater.new()
+	_input_map_updater._ready()
+
+
+func _exit_tree():
+	if is_instance_valid(_input_map_updater): 
+		_input_map_updater.queue_free()


### PR DESCRIPTION
Hi, according to the [Godot Documentation](https://docs.godotengine.org/en/4.0/tutorials/scripting/nodes_and_scene_instances.html#creating-nodes), when a node is creating with the `new` method, we need to free it from memory with the `queue_free` method.

Below, the commands I ran after pulling the project :

Before :
```shell
$ godot --headless --quit --verbose
Godot Engine v4.0.3.stable.official.5222a99f5 - https://godotengine.org
...
Loading resource: res://addons/EasyMenus/Nodes/menu_template_manager.tscn
Loaded builtin certs
...
ERROR: Condition "_first != nullptr" is true.
   at: ~List (./core/templates/self_list.h:106)
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:1982)
Leaked instance: GDScriptNativeClass:-9223138390633873009
Leaked instance: GDScript:-9222563895808359228 - Resource path: res://addons/EasyMenus/Scripts/input_map_updater.gd
Leaked instance: Node:991759488255175 - Node name: 
Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).
ERROR: Resources still in use at exit (run with --verbose for details).
   at: clear (core/io/resource.cpp:489)
Resource still in use: res://addons/EasyMenus/Scripts/input_map_updater.gd (GDScript)
...
```
After : 
```shell
$ godot --headless --quit --verbose
Godot Engine v4.0.3.stable.official.5222a99f5 - https://godotengine.org
...
Loading resource: res://addons/EasyMenus/Nodes/menu_template_manager.tscn
Loaded builtin certs
...
```